### PR TITLE
Fix for AliDPG chain: add switch to disable storage of primordial particles

### DIFF
--- a/build/include/Therminator2ToHepMCParser.h
+++ b/build/include/Therminator2ToHepMCParser.h
@@ -16,7 +16,7 @@ class Therminator2ToHepMCParser
 {
   public:
     Therminator2ToHepMCParser();
-    Therminator2ToHepMCParser(std::string inputFileName, std::string outputFileName);
+    Therminator2ToHepMCParser(std::string inputFileName, std::string outputFileName, bool savePrimordialPositions);
        
     void Run();
   private:
@@ -26,6 +26,7 @@ class Therminator2ToHepMCParser
 
     std::string inputFileName;
     std::string outputFileName;
+    bool savePrimordialPositions;
 
     std::ifstream inputStream;
 

--- a/build/src/Therminator2ToHepMCParser.cxx
+++ b/build/src/Therminator2ToHepMCParser.cxx
@@ -8,10 +8,11 @@ Therminator2ToHepMCParser::Therminator2ToHepMCParser():_HepMC_writer(0)
     
 }
 
-Therminator2ToHepMCParser::Therminator2ToHepMCParser(string inputFileName, string outputFileName):_HepMC_writer(0)
+Therminator2ToHepMCParser::Therminator2ToHepMCParser(string inputFileName, string outputFileName, bool savePrimordialPositions):_HepMC_writer(0)
 {
     this->inputFileName = inputFileName;
     this->outputFileName = outputFileName;
+    this->savePrimordialPositions = savePrimordialPositions;
 }
 
 void Therminator2ToHepMCParser::Run()
@@ -131,21 +132,28 @@ void Therminator2ToHepMCParser::Run()
                 out_vertex = eidToVertex->at(_particle.fathereid);
             else
             {
-                // If it's a primordial particle, create a pseudo particle for connection
-                // and its production vertex. 
-                FourVector hyperVector(0, 0, 0, 0);
-                GenParticle* hypersurface = new GenParticle(hyperVector, 0, 0);
-                v->add_particle_out(hypersurface);
+                if(savePrimordialPositions)
+                {
+                    // If it's a primordial particle, create a pseudo particle for connection
+                    // and its production vertex. 
+                    FourVector hyperVector(0,0,.14e4, 1686.2977);
+                    GenParticle* hypersurface = new GenParticle(hyperVector, 2212, 2);
+                    v->add_particle_out(hypersurface);
 
-                out_vertex = new GenVertex();
-                out_vertex->add_particle_in(hypersurface);
-                parsed_event.add_vertex(out_vertex);
-                FourVector spaceTimePos(
-                            _particle.x*fm_to_mm,
-                            _particle.y*fm_to_mm, 
-                            _particle.z*fm_to_mm, 
-                            _particle.t*fm_to_mm);
-                out_vertex->set_position(spaceTimePos);
+                    out_vertex = new GenVertex();
+                    out_vertex->add_particle_in(hypersurface);
+                    parsed_event.add_vertex(out_vertex);
+                    FourVector spaceTimePos(
+                                _particle.x*fm_to_mm,
+                                _particle.y*fm_to_mm, 
+                                _particle.z*fm_to_mm, 
+                                _particle.t*fm_to_mm);
+                    out_vertex->set_position(spaceTimePos);
+                }
+                else
+                    // If we do not care about the positions of primordial particles
+                    // They are linked directly to the primary vertex
+                    out_vertex = v;
             }
             
             // If not already done, set the creation position

--- a/build/src/therm2_parser.cxx
+++ b/build/src/therm2_parser.cxx
@@ -15,13 +15,15 @@ using std::string;
 void printUsage(char* progName)
 {
     printf("Converts Therminator2 text output file to the HepMC format. Usage:\n");
-    printf("%s <input_file> <output_file>\n", progName);
+    printf("%s <input_file> <output_file> [-d]\n", progName);
+    printf("-d\tDisable pseudo-particles. The output file won't contain additional linking particles. ");
+    printf("However, the positions of primary particles won't be saved.\n");
 }
 
 int main(int argc, char* argv[])
 {
-    printf("Therminator2 parser version 2.0\n");
-    if(argc < 3)
+    printf("Therminator2 parser version 2.1\n");
+    if(argc < 3 || argc > 4)
     {
         printUsage(argv[0]);
         return 1;
@@ -34,10 +36,27 @@ int main(int argc, char* argv[])
         return 1;
     }
     
+    bool savePrimordialPositions = true;
+    
+    if(argc == 4)
+    {
+        string extraParam = argv[3];
+        if(extraParam == "-d")
+        {
+            savePrimordialPositions = false;
+            printf("Disabling pseudo-particles.\n");
+        }
+        else
+        {
+            printf("Unknown parameter: %s, quitting...", argv[3]);
+            return 1;
+        }
+    }
+    
     string inputFileName = firstArg;
     string outputFileName = argv[2];
 
-    Therminator2ToHepMCParser* parser = new Therminator2ToHepMCParser(inputFileName, outputFileName);
+    Therminator2ToHepMCParser* parser = new Therminator2ToHepMCParser(inputFileName, outputFileName, savePrimordialPositions);
     parser->Run();
     
     return 0;


### PR DESCRIPTION
The pseudo-particles created in the parser have now nonzero energy and longitudinal momentum, so they should not crash the reconstruction.

I have also added a switch to the parser which turns off the pseudo-particles altogether.